### PR TITLE
Fix brew references in make tasks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ RUBY := $(shell which ruby)
 BREW := $(shell which brew)
 SWIFT := $(shell which swift)
 SWIFTLINT := $(shell which swiftlint)
+CURL := $(shell which curl)
 
 
 # Generates the xcodeproj and compiles the executable
@@ -44,15 +45,15 @@ endif
 
 install-homebrew:
 ifndef BREW
-	$(RUBY) -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	$(RUBY) -e "$($(CURL) -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 else
-	brew update
+	$(BREW) update
 endif
 
 
 install-swiftlint:
 ifndef SWIFTLINT
-	brew install swiftlint
+	$(BREW) install swiftlint
 else
-	brew outdated swiftlint || brew upgrade swiftlint
+	$(BREW) outdated swiftlint || $(BREW) upgrade swiftlint
 endif


### PR DESCRIPTION
### Summary

To keep consistency when running brew commands, the references should always
be `$(BREW)` so it will use the right one (by default whatever comes from
`which brew` but also can be overwitten via `make foo BREW=mybrew`.

Also, same rationale for `curl`.

### Review

Test brew commands run as expected. A reasonably simple way to check a task relies on a variable instead of a hardcoded binary name is to run `make taskname BREW=echo`.